### PR TITLE
Fixed the proximity sensoring when call is active

### DIFF
--- a/Example/VialerSIPLib/VSLCallViewController.swift
+++ b/Example/VialerSIPLib/VSLCallViewController.swift
@@ -45,6 +45,7 @@ class VSLCallViewController: UIViewController, VSLKeypadViewControllerDelegate {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        UIDevice.current.isProximityMonitoringEnabled = true
         updateUI()
         startConnectDurationTimer()
         activeCall?.addObserver(self, forKeyPath: "callState", options: .new, context: &myContext)
@@ -54,6 +55,7 @@ class VSLCallViewController: UIViewController, VSLKeypadViewControllerDelegate {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+        UIDevice.current.isProximityMonitoringEnabled = false
         connectDurationTimer?.invalidate()
         activeCall?.removeObserver(self, forKeyPath: "callState")
         activeCall?.removeObserver(self, forKeyPath: "onHold")

--- a/Example/VialerSIPLib/VSLTransferCallViewController.swift
+++ b/Example/VialerSIPLib/VSLTransferCallViewController.swift
@@ -34,7 +34,6 @@ private var myContext = 0
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        UIDevice.current.isProximityMonitoringEnabled = false
         updateUI()
         currentCall?.addObserver(self, forKeyPath: "callState", options: .new, context: &myContext)
     }
@@ -60,7 +59,6 @@ private var myContext = 0
     }
 
     @IBAction override func callButtonPressed(_ sender: UIButton) {
-        UIDevice.current.isProximityMonitoringEnabled = true
         guard let number = numberToDialLabel.text, number != "" else { return }
 
         callManager.startCall(toNumber: number, for: currentCall!.account! ) { (call, error) in


### PR DESCRIPTION
When the call is active, the proximity sensor should be enabled to prevent unwanted touches to the screen.