### PR TITLE
Make sure sipproxy can be set optional

### DIFF
--- a/Example/VialerSIPLib.xcodeproj/project.pbxproj
+++ b/Example/VialerSIPLib.xcodeproj/project.pbxproj
@@ -124,10 +124,10 @@
 		C487361E1C4F96B200604413 /* Credits.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = Credits.md; path = ../Documentation/Credits.md; sourceTree = "<group>"; };
 		C48B488D1D421CB100AB2875 /* SipUser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SipUser.swift; sourceTree = "<group>"; };
 		C48B488F1D42228900AB2875 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		C497FF8C1E3F2E6900D0363B /* PULL_REQUEST_TEMPLATE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = PULL_REQUEST_TEMPLATE.md; path = ../.github/PULL_REQUEST_TEMPLATE.md; sourceTree = "<group>"; };
 		C49B2C3A1DF9B9CB000FFBF7 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = CHANGELOG.md; path = ../CHANGELOG.md; sourceTree = "<group>"; };
 		C4A5C09D1E3640CF008F5297 /* CONTRIBUTING.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = CONTRIBUTING.md; path = ../Documentation/CONTRIBUTING.md; sourceTree = "<group>"; };
 		C4A5C09F1E364121008F5297 /* ISSUE_TEMPLATE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = ISSUE_TEMPLATE.md; path = ../.github/ISSUE_TEMPLATE.md; sourceTree = "<group>"; };
-		C4A5C0A01E364140008F5297 /* PULL_REQUEST_TEMPLATE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = PULL_REQUEST_TEMPLATE.md; sourceTree = "<group>"; };
 		C4A6D7661D5A12720014A4FB /* Keys.swift.example */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Keys.swift.example; sourceTree = "<group>"; };
 		C64094058567ED161343B634 /* Pods-VialerSIPLib_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VialerSIPLib_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-VialerSIPLib_Example/Pods-VialerSIPLib_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		E4DBAC75C9B3D560D6779049 /* Pods-VialerSIPLib_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VialerSIPLib_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-VialerSIPLib_Tests/Pods-VialerSIPLib_Tests.release.xcconfig"; sourceTree = "<group>"; };
@@ -280,7 +280,7 @@
 				C49B2C3A1DF9B9CB000FFBF7 /* CHANGELOG.md */,
 				751644FF6D649E93790619BF /* LICENSE */,
 				C4A5C09F1E364121008F5297 /* ISSUE_TEMPLATE.md */,
-				C4A5C0A01E364140008F5297 /* PULL_REQUEST_TEMPLATE.md */,
+				C497FF8C1E3F2E6900D0363B /* PULL_REQUEST_TEMPLATE.md */,
 				C48736151C4F901600604413 /* Documentation */,
 			);
 			name = "Podspec Metadata";

--- a/Example/VialerSIPLib/SipUser.swift
+++ b/Example/VialerSIPLib/SipUser.swift
@@ -10,7 +10,7 @@ class SipUser: NSObject, SIPEnabledUser {
     let sipAccount: String
     let sipPassword: String
     let sipDomain: String
-    let sipProxy: String
+    let sipProxy: String?
     let sipRegisterOnAdd: Bool
 
     init(sipAccount: String, sipPassword: String, sipDomain: String, sipProxy: String) {

--- a/Pod/Classes/VialerSIPLib.h
+++ b/Pod/Classes/VialerSIPLib.h
@@ -71,7 +71,7 @@ typedef NS_ENUM(NSUInteger, VialerSIPLibErrors) {
  *
  *  @return NSString with the proxy Address.
  */
-@property (readonly, nonatomic) NSString * _Nonnull sipProxy;
+@property (readonly, nonatomic) NSString * _Nullable sipProxy;
 
 /**
  * Control the use of STUN for the SIP signaling.

--- a/Pod/Classes/VialerSIPLib.m
+++ b/Pod/Classes/VialerSIPLib.m
@@ -92,7 +92,9 @@ static NSString * const VialerSIPLibErrorDomain = @"VialerSIPLib.error";
         accountConfiguration.sipAccount = sipUser.sipAccount;
         accountConfiguration.sipPassword = sipUser.sipPassword;
         accountConfiguration.sipDomain = sipUser.sipDomain;
-        accountConfiguration.sipProxyServer = sipUser.sipProxy ? sipUser.sipProxy : @"";
+        if ([sipUser respondsToSelector:@selector(sipProxy)]) {
+            accountConfiguration.sipProxyServer = sipUser.sipProxy;
+        }
         accountConfiguration.sipRegisterOnAdd = sipUser.sipRegisterOnAdd;
         accountConfiguration.dropCallOnRegistrationFailure = YES;
         


### PR DESCRIPTION
### Issue number

This will fix #59

### Expected behaviour

SIP Proxy should be an optional parameter

### Actual behaviour

When not provided, the app will crash

### Description of fix

Changed property to optional and made sure it will not be used when not present

### Other info
