### PR TITLE
Prevent crash

### DIFF
--- a/Pod/Classes/VSLEndpoint.m
+++ b/Pod/Classes/VSLEndpoint.m
@@ -279,20 +279,16 @@ static pjsip_transport *the_transport;
         }
     }
 
+    
+    if (self.pjPool != NULL) {
+        pj_pool_safe_release(&self->_pjPool);
+    }
+    
     // Destroy PJSUA.
     pj_status_t status = pjsua_destroy();
     if (status != PJ_SUCCESS) {
         VSLLogWarning(@"Error stopping SIP Endpoint");
     }
-
-    @try {
-        if (self.pjPool != NULL) {
-            pj_pool_safe_release(&self->_pjPool);
-        }
-    } @catch (NSException *exception) {
-        VSLLogError(@"%Error stopping _pjPool @",[exception description]);
-    }
-
 
     self.state = VSLEndpointStopped;
 }


### PR DESCRIPTION
Destroy pjsua. Application is recommended to perform graceful shutdown before calling this function (such as unregister the account from the SIP server, terminate presense subscription, and hangup active calls), however,  this function will do all of these if it finds there are active sessions  that need to be terminated. This function will approximately block for  one second to wait for replies from remote.)
