### PR TITLE
Updated to XCode9 and PJSIP 2.7, added a new notification for dealloced call.

### DIFF
--- a/Example/IntentsExtension/IntentHandler.swift
+++ b/Example/IntentsExtension/IntentHandler.swift
@@ -12,7 +12,7 @@ import Intents
 
 class IntentHandler: INExtension, INStartAudioCallIntentHandling {
 
-    func handle(startAudioCall intent: INStartAudioCallIntent, completion: @escaping (INStartAudioCallIntentResponse) -> Void) {
+    func handle(intent: INStartAudioCallIntent, completion: @escaping (INStartAudioCallIntentResponse) -> Void) {
         let response: INStartAudioCallIntentResponse
         defer {
             completion(response)

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,15 +1,13 @@
 PODS:
-  - CocoaLumberjack (3.0.0):
-    - CocoaLumberjack/Default (= 3.0.0)
-    - CocoaLumberjack/Extensions (= 3.0.0)
-  - CocoaLumberjack/Core (3.0.0)
-  - CocoaLumberjack/Default (3.0.0):
-    - CocoaLumberjack/Core
-  - CocoaLumberjack/Extensions (3.0.0):
+  - CocoaLumberjack (3.3.0):
+    - CocoaLumberjack/Default (= 3.3.0)
+    - CocoaLumberjack/Extensions (= 3.3.0)
+  - CocoaLumberjack/Default (3.3.0)
+  - CocoaLumberjack/Extensions (3.3.0):
     - CocoaLumberjack/Default
   - OCMock (3.4)
   - Reachability (3.2)
-  - Vialer-pjsip-iOS (2.0.1)
+  - Vialer-pjsip-iOS (3.0.0)
   - VialerSIPLib (2.7.0):
     - CocoaLumberjack
     - Reachability
@@ -26,10 +24,10 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  CocoaLumberjack: c823149bccc5519a9447aeb433be7b1212a7d6a5
+  CocoaLumberjack: 3c8c74683302f9012bb168e1c4b7ae3c0b558431
   OCMock: 35ae71d6a8fcc1b59434d561d1520b9dd4f15765
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
-  Vialer-pjsip-iOS: 8f9073448404525d53f3aa4b9517e3b2b9aae2c7
+  Vialer-pjsip-iOS: b1ab5df145e892449914a864fd85b8d869204449
   VialerSIPLib: c91e5d897e9200de8867b68b500d63c40a986372
 
 PODFILE CHECKSUM: 0f7b04fb045caf39ed7c2486524959b2d2be90e8

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/aes.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/aes.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/aes.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/asn1.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/asn1.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/asn1.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/asn1_mac.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/asn1_mac.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/asn1_mac.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/asn1t.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/asn1t.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/asn1t.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/bio.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/bio.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/bio.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/blowfish.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/blowfish.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/blowfish.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/bn.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/bn.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/bn.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/buffer.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/buffer.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/buffer.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/camellia.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/camellia.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/camellia.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/cast.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/cast.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/cast.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/cmac.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/cmac.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/cmac.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/cms.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/cms.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/cms.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/comp.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/comp.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/comp.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/conf.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/conf.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/conf.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/conf_api.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/conf_api.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/conf_api.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/crypto.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/crypto.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/crypto.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/des.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/des.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/des.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/des_old.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/des_old.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/des_old.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/dh.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/dh.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/dh.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/dsa.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/dsa.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/dsa.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/dso.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/dso.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/dso.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/dtls1.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/dtls1.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/dtls1.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/e_os2.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/e_os2.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/e_os2.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ebcdic.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ebcdic.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ebcdic.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ec.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ec.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ec.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ecdh.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ecdh.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ecdh.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ecdsa.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ecdsa.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ecdsa.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/engine.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/engine.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/engine.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/err.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/err.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/err.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/evp.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/evp.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/evp.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/hmac.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/hmac.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/hmac.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/idea.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/idea.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/idea.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/krb5_asn.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/krb5_asn.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/krb5_asn.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/kssl.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/kssl.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/kssl.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/lhash.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/lhash.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/lhash.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/md4.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/md4.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/md4.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/md5.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/md5.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/md5.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/mdc2.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/mdc2.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/mdc2.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/modes.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/modes.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/modes.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/obj_mac.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/obj_mac.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/obj_mac.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/objects.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/objects.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/objects.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ocsp.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ocsp.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ocsp.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/opensslconf.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/opensslconf.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/opensslconf.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/opensslconf_ios_arm64.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/opensslconf_ios_arm64.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/opensslconf_ios_arm64.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/opensslconf_ios_armv7.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/opensslconf_ios_armv7.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/opensslconf_ios_armv7.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/opensslconf_ios_armv7s.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/opensslconf_ios_armv7s.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/opensslconf_ios_armv7s.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/opensslconf_ios_i386.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/opensslconf_ios_i386.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/opensslconf_ios_i386.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/opensslconf_ios_x86_64.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/opensslconf_ios_x86_64.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/opensslconf_ios_x86_64.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/opensslv.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/opensslv.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/opensslv.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ossl_typ.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ossl_typ.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ossl_typ.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/pem.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/pem.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/pem.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/pem2.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/pem2.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/pem2.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/pkcs12.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/pkcs12.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/pkcs12.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/pkcs7.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/pkcs7.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/pkcs7.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/pqueue.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/pqueue.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/pqueue.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/rand.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/rand.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/rand.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/rc2.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/rc2.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/rc2.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/rc4.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/rc4.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/rc4.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ripemd.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ripemd.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ripemd.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/rsa.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/rsa.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/rsa.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/safestack.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/safestack.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/safestack.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/seed.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/seed.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/seed.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/sha.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/sha.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/sha.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/srp.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/srp.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/srp.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/srtp.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/srtp.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/srtp.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ssl.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ssl.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ssl.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ssl2.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ssl2.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ssl2.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ssl23.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ssl23.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ssl23.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ssl3.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ssl3.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ssl3.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/stack.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/stack.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/stack.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/symhacks.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/symhacks.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/symhacks.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/tls1.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/tls1.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/tls1.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ts.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ts.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ts.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/txt_db.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/txt_db.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/txt_db.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ui.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ui.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ui.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ui_compat.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ui_compat.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/ui_compat.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/whrlpool.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/whrlpool.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/whrlpool.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/x509.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/x509.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/x509.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/x509_vfy.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/x509_vfy.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/x509_vfy.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/x509v3.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/x509v3.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/openssl/x509v3.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/opus/opus.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/opus/opus.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/opus/opus.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/opus/opus_defines.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/opus/opus_defines.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/opus/opus_defines.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/opus/opus_multistream.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/opus/opus_multistream.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/opus/opus_multistream.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/opus/opus_types.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/opus/opus_types.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/opus/opus_types.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/file.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/file.hpp
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/file.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/hash.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/hash.hpp
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/hash.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/list.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/list.hpp
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/list.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/lock.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/lock.hpp
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/lock.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/os.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/os.hpp
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/os.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/pool.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/pool.hpp
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/pool.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/proactor.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/proactor.hpp
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/proactor.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/scanner.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/scanner.hpp
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/scanner.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/sock.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/sock.hpp
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/sock.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/string.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/string.hpp
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/string.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/timer.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/timer.hpp
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/timer.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/tree.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/tree.hpp
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/tree.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/types.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/types.hpp
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj++/types.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/activesock.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/activesock.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/activesock.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/addr_resolv.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/addr_resolv.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/addr_resolv.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/array.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/array.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/array.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/assert.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/assert.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/assert.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/assert.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/assert.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/assert.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/cc_armcc.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/cc_armcc.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/cc_armcc.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/cc_codew.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/cc_codew.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/cc_codew.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/cc_gcc.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/cc_gcc.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/cc_gcc.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/cc_gcce.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/cc_gcce.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/cc_gcce.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/cc_msvc.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/cc_msvc.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/cc_msvc.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/cc_mwcc.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/cc_mwcc.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/cc_mwcc.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/ctype.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/ctype.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/ctype.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/errno.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/errno.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/errno.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/high_precision.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/high_precision.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/high_precision.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/m_alpha.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/m_alpha.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/m_alpha.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/m_armv4.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/m_armv4.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/m_armv4.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/m_auto.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/m_auto.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/m_auto.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/m_i386.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/m_i386.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/m_i386.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/m_m68k.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/m_m68k.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/m_m68k.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/m_powerpc.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/m_powerpc.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/m_powerpc.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/m_sparc.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/m_sparc.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/m_sparc.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/m_x86_64.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/m_x86_64.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/m_x86_64.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/malloc.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/malloc.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/malloc.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_auto.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_auto.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_auto.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_darwinos.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_darwinos.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_darwinos.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_linux.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_linux.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_linux.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_linux_kernel.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_linux_kernel.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_linux_kernel.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_palmos.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_palmos.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_palmos.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_rtems.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_rtems.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_rtems.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_sunos.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_sunos.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_sunos.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_symbian.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_symbian.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_symbian.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_win32.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_win32.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_win32.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_win32_wince.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_win32_wince.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_win32_wince.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_winphone8.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_winphone8.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_winphone8.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_winuwp.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_winuwp.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/os_winuwp.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/rand.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/rand.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/rand.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/setjmp.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/setjmp.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/setjmp.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/size_t.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/size_t.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/size_t.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/socket.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/socket.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/socket.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/stdarg.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/stdarg.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/stdarg.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/stdfileio.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/stdfileio.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/stdfileio.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/string.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/string.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/string.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/time.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/time.h
@@ -1,0 +1,1 @@
+../../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/compat/time.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/config.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/config.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/config.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/config_site.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/config_site.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/config_site.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/config_site_sample.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/config_site_sample.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/config_site_sample.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/ctype.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/ctype.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/ctype.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/doxygen.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/doxygen.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/doxygen.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/errno.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/errno.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/errno.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/except.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/except.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/except.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/fifobuf.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/fifobuf.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/fifobuf.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/file_access.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/file_access.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/file_access.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/file_io.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/file_io.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/file_io.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/guid.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/guid.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/guid.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/hash.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/hash.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/hash.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/ioqueue.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/ioqueue.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/ioqueue.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/ip_helper.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/ip_helper.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/ip_helper.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/list.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/list.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/list.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/list_i.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/list_i.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/list_i.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/lock.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/lock.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/lock.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/log.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/log.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/log.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/math.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/math.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/math.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/os.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/os.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/os.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/pool.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/pool.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/pool.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/pool_alt.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/pool_alt.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/pool_alt.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/pool_buf.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/pool_buf.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/pool_buf.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/pool_i.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/pool_i.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/pool_i.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/rand.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/rand.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/rand.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/rbtree.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/rbtree.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/rbtree.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/sock.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/sock.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/sock.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/sock_qos.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/sock_qos.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/sock_qos.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/sock_select.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/sock_select.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/sock_select.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/ssl_sock.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/ssl_sock.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/ssl_sock.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/string.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/string.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/string.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/string_i.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/string_i.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/string_i.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/timer.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/timer.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/timer.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/types.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/types.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/types.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/unicode.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/unicode.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pj/unicode.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib++.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib++.hpp
@@ -1,0 +1,1 @@
+../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib++.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util.h
@@ -1,0 +1,1 @@
+../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/base64.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/base64.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/base64.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/cli.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/cli.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/cli.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/cli_console.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/cli_console.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/cli_console.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/cli_imp.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/cli_imp.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/cli_imp.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/cli_telnet.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/cli_telnet.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/cli_telnet.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/config.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/config.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/config.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/crc32.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/crc32.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/crc32.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/dns.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/dns.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/dns.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/dns_server.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/dns_server.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/dns_server.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/errno.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/errno.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/errno.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/getopt.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/getopt.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/getopt.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/hmac_md5.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/hmac_md5.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/hmac_md5.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/hmac_sha1.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/hmac_sha1.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/hmac_sha1.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/http_client.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/http_client.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/http_client.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/json.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/json.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/json.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/md5.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/md5.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/md5.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/pcap.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/pcap.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/pcap.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/resolver.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/resolver.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/resolver.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/scanner.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/scanner.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/scanner.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/scanner_cis_bitwise.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/scanner_cis_bitwise.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/scanner_cis_bitwise.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/scanner_cis_uint.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/scanner_cis_uint.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/scanner_cis_uint.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/sha1.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/sha1.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/sha1.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/srv_resolver.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/srv_resolver.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/srv_resolver.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/string.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/string.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/string.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/stun_simple.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/stun_simple.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/stun_simple.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/types.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/types.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/types.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/xml.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/xml.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib-util/xml.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib.h
@@ -1,0 +1,1 @@
+../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjlib.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-audiodev/audiodev.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-audiodev/audiodev.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-audiodev/audiodev.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-audiodev/audiodev_imp.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-audiodev/audiodev_imp.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-audiodev/audiodev_imp.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-audiodev/audiotest.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-audiodev/audiotest.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-audiodev/audiotest.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-audiodev/config.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-audiodev/config.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-audiodev/config.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-audiodev/errno.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-audiodev/errno.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-audiodev/errno.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec.h
@@ -1,0 +1,1 @@
+../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/amr_helper.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/amr_helper.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/amr_helper.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/amr_sdp_match.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/amr_sdp_match.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/amr_sdp_match.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/audio_codecs.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/audio_codecs.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/audio_codecs.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/bcg729.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/bcg729.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/bcg729.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/config.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/config.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/config.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/config_auto.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/config_auto.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/config_auto.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/ffmpeg_vid_codecs.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/ffmpeg_vid_codecs.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/ffmpeg_vid_codecs.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/g722.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/g722.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/g722.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/g7221.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/g7221.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/g7221.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/g7221_sdp_match.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/g7221_sdp_match.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/g7221_sdp_match.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/gsm.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/gsm.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/gsm.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/h263_packetizer.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/h263_packetizer.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/h263_packetizer.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/h264_packetizer.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/h264_packetizer.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/h264_packetizer.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/ilbc.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/ilbc.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/ilbc.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/ipp_codecs.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/ipp_codecs.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/ipp_codecs.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/l16.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/l16.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/l16.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/opencore_amr.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/opencore_amr.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/opencore_amr.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/openh264.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/openh264.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/openh264.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/opus.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/opus.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/opus.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/passthrough.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/passthrough.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/passthrough.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/silk.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/silk.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/silk.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/speex.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/speex.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/speex.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/types.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/types.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/types.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/vid_toolbox.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/vid_toolbox.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-codec/vid_toolbox.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-videodev/avi_dev.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-videodev/avi_dev.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-videodev/avi_dev.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-videodev/config.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-videodev/config.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-videodev/config.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-videodev/errno.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-videodev/errno.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-videodev/errno.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-videodev/opengl_dev.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-videodev/opengl_dev.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-videodev/opengl_dev.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-videodev/videodev.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-videodev/videodev.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-videodev/videodev.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-videodev/videodev_imp.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-videodev/videodev_imp.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia-videodev/videodev_imp.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia.h
@@ -1,0 +1,1 @@
+../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/alaw_ulaw.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/alaw_ulaw.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/alaw_ulaw.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/audiodev.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/audiodev.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/audiodev.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/avi.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/avi.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/avi.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/avi_stream.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/avi_stream.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/avi_stream.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/bidirectional.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/bidirectional.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/bidirectional.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/circbuf.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/circbuf.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/circbuf.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/clock.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/clock.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/clock.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/codec.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/codec.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/codec.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/conference.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/conference.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/conference.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/config.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/config.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/config.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/config_auto.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/config_auto.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/config_auto.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/converter.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/converter.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/converter.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/delaybuf.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/delaybuf.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/delaybuf.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/doxygen.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/doxygen.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/doxygen.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/echo.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/echo.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/echo.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/echo_port.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/echo_port.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/echo_port.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/endpoint.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/endpoint.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/endpoint.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/errno.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/errno.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/errno.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/event.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/event.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/event.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/format.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/format.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/format.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/frame.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/frame.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/frame.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/g711.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/g711.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/g711.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/jbuf.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/jbuf.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/jbuf.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/master_port.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/master_port.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/master_port.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/mem_port.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/mem_port.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/mem_port.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/null_port.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/null_port.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/null_port.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/plc.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/plc.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/plc.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/port.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/port.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/port.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/resample.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/resample.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/resample.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/rtcp.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/rtcp.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/rtcp.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/rtcp_xr.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/rtcp_xr.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/rtcp_xr.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/rtp.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/rtp.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/rtp.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/sdp.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/sdp.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/sdp.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/sdp_neg.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/sdp_neg.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/sdp_neg.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/session.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/session.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/session.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/signatures.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/signatures.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/signatures.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/silencedet.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/silencedet.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/silencedet.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/sound.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/sound.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/sound.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/sound_port.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/sound_port.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/sound_port.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/splitcomb.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/splitcomb.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/splitcomb.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/stereo.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/stereo.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/stereo.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/stream.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/stream.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/stream.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/stream_common.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/stream_common.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/stream_common.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/symbian_sound_aps.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/symbian_sound_aps.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/symbian_sound_aps.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/tonegen.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/tonegen.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/tonegen.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/transport.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/transport.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/transport.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/transport_adapter_sample.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/transport_adapter_sample.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/transport_adapter_sample.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/transport_ice.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/transport_ice.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/transport_ice.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/transport_loop.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/transport_loop.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/transport_loop.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/transport_srtp.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/transport_srtp.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/transport_srtp.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/transport_udp.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/transport_udp.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/transport_udp.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/types.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/types.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/types.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/vid_codec.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/vid_codec.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/vid_codec.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/vid_codec_util.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/vid_codec_util.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/vid_codec_util.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/vid_port.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/vid_port.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/vid_port.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/vid_stream.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/vid_stream.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/vid_stream.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/vid_tee.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/vid_tee.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/vid_tee.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/videodev.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/videodev.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/videodev.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/wav_playlist.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/wav_playlist.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/wav_playlist.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/wav_port.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/wav_port.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/wav_port.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/wave.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/wave.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/wave.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/wsola.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/wsola.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia/wsola.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia_audiodev.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia_audiodev.h
@@ -1,0 +1,1 @@
+../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia_audiodev.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia_videodev.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia_videodev.h
@@ -1,0 +1,1 @@
+../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjmedia_videodev.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath.h
@@ -1,0 +1,1 @@
+../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/config.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/config.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/config.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/errno.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/errno.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/errno.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/ice_session.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/ice_session.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/ice_session.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/ice_strans.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/ice_strans.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/ice_strans.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/nat_detect.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/nat_detect.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/nat_detect.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/stun_auth.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/stun_auth.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/stun_auth.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/stun_config.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/stun_config.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/stun_config.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/stun_msg.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/stun_msg.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/stun_msg.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/stun_session.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/stun_session.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/stun_session.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/stun_sock.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/stun_sock.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/stun_sock.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/stun_transaction.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/stun_transaction.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/stun_transaction.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/turn_session.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/turn_session.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/turn_session.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/turn_sock.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/turn_sock.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/turn_sock.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/types.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/types.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjnath/types.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/errno.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/errno.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/errno.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/evsub.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/evsub.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/evsub.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/evsub_msg.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/evsub_msg.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/evsub_msg.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/iscomposing.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/iscomposing.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/iscomposing.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/mwi.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/mwi.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/mwi.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/pidf.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/pidf.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/pidf.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/presence.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/presence.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/presence.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/publish.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/publish.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/publish.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/rpid.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/rpid.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/rpid.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/types.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/types.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/types.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/xpidf.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/xpidf.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-simple/xpidf.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-ua/sip_100rel.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-ua/sip_100rel.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-ua/sip_100rel.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-ua/sip_inv.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-ua/sip_inv.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-ua/sip_inv.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-ua/sip_regc.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-ua/sip_regc.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-ua/sip_regc.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-ua/sip_replaces.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-ua/sip_replaces.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-ua/sip_replaces.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-ua/sip_timer.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-ua/sip_timer.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-ua/sip_timer.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-ua/sip_xfer.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-ua/sip_xfer.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip-ua/sip_xfer.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip.h
@@ -1,0 +1,1 @@
+../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/print_util.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/print_util.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/print_util.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_auth.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_auth.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_auth.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_auth_aka.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_auth_aka.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_auth_aka.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_auth_msg.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_auth_msg.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_auth_msg.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_auth_parser.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_auth_parser.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_auth_parser.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_autoconf.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_autoconf.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_autoconf.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_config.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_config.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_config.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_dialog.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_dialog.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_dialog.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_endpoint.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_endpoint.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_endpoint.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_errno.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_errno.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_errno.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_event.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_event.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_event.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_module.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_module.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_module.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_msg.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_msg.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_msg.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_multipart.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_multipart.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_multipart.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_parser.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_parser.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_parser.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_private.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_private.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_private.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_resolve.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_resolve.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_resolve.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_tel_uri.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_tel_uri.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_tel_uri.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_transaction.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_transaction.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_transaction.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_transport.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_transport.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_transport.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_transport_loop.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_transport_loop.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_transport_loop.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_transport_tcp.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_transport_tcp.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_transport_tcp.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_transport_tls.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_transport_tls.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_transport_tls.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_transport_udp.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_transport_udp.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_transport_udp.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_types.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_types.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_types.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_ua_layer.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_ua_layer.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_ua_layer.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_uri.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_uri.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_uri.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_util.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_util.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip/sip_util.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip_auth.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip_auth.h
@@ -1,0 +1,1 @@
+../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip_auth.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip_simple.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip_simple.h
@@ -1,0 +1,1 @@
+../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip_simple.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip_ua.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip_ua.h
@@ -1,0 +1,1 @@
+../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsip_ua.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua-lib/pjsua.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua-lib/pjsua.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua-lib/pjsua.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua-lib/pjsua_internal.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua-lib/pjsua_internal.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua-lib/pjsua_internal.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua.h
@@ -1,0 +1,1 @@
+../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2.hpp
@@ -1,0 +1,1 @@
+../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/account.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/account.hpp
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/account.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/call.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/call.hpp
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/call.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/config.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/config.hpp
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/config.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/doxygen.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/doxygen.hpp
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/doxygen.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/endpoint.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/endpoint.hpp
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/endpoint.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/json.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/json.hpp
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/json.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/media.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/media.hpp
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/media.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/persistent.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/persistent.hpp
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/persistent.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/presence.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/presence.hpp
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/presence.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/siptypes.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/siptypes.hpp
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/siptypes.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/types.hpp
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/types.hpp
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/pjsua2/types.hpp

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/wels/codec_api.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/wels/codec_api.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/wels/codec_api.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/wels/codec_app_def.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/wels/codec_app_def.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/wels/codec_app_def.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/wels/codec_def.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/wels/codec_def.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/wels/codec_def.h

--- a/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/wels/codec_ver.h
+++ b/Example/Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/wels/codec_ver.h
@@ -1,0 +1,1 @@
+../../../../../../../../Vialer-pjsip-iOS/VialerPJSIP.framework/Versions/A/Headers/wels/codec_ver.h

--- a/Example/VialerSIPLib.xcodeproj/project.pbxproj
+++ b/Example/VialerSIPLib.xcodeproj/project.pbxproj
@@ -453,12 +453,12 @@
 			attributes = {
 				CLASSPREFIX = VSL;
 				LastSwiftUpdateCheck = 0800;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = Harold;
 				TargetAttributes = {
 					6003F589195388D20070C39A = {
 						DevelopmentTeam = E2Q9UE8HM6;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
@@ -467,12 +467,13 @@
 						};
 					};
 					6003F5AD195388D20070C39A = {
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 						TestTargetID = 6003F589195388D20070C39A;
 					};
 					F271B54A1DABD18F0028D620 = {
 						CreatedOnToolsVersion = 8.0;
 						DevelopmentTeam = E2Q9UE8HM6;
+						LastSwiftMigration = 0900;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -568,7 +569,7 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-VialerSIPLib_Example/Pods-VialerSIPLib_Example-resources.sh",
-				"$PODS_CONFIGURATION_BUILD_DIR/VialerSIPLib/VialerSIPLib.bundle",
+				$PODS_CONFIGURATION_BUILD_DIR/VialerSIPLib/VialerSIPLib.bundle,
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -604,7 +605,7 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-VialerSIPLib_Tests/Pods-VialerSIPLib_Tests-resources.sh",
-				"$PODS_CONFIGURATION_BUILD_DIR/VialerSIPLib/VialerSIPLib.bundle",
+				$PODS_CONFIGURATION_BUILD_DIR/VialerSIPLib/VialerSIPLib.bundle,
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -731,14 +732,20 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -776,14 +783,20 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -827,7 +840,8 @@
 				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "VialerSIPLib/VialerSIPLib_Example-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -850,7 +864,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "VialerSIPLib/VialerSIPLib_Example-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
@@ -869,7 +884,8 @@
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/VialerSIPLib_Example.app/VialerSIPLib_Example";
 				WRAPPER_EXTENSION = xctest;
 			};
@@ -885,7 +901,8 @@
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/VialerSIPLib_Example.app/VialerSIPLib_Example";
 				WRAPPER_EXTENSION = xctest;
 			};
@@ -910,7 +927,8 @@
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -932,7 +950,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = nl.voipgrid.VialerSIPLib.IntentsExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/Example/VialerSIPLib.xcodeproj/xcshareddata/xcschemes/VialerSIPLib-Example.xcscheme
+++ b/Example/VialerSIPLib.xcodeproj/xcshareddata/xcschemes/VialerSIPLib-Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
       <Testables>
@@ -56,6 +57,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Example/VialerSIPLib/DDLogWrapper.m
+++ b/Example/VialerSIPLib/DDLogWrapper.m
@@ -8,10 +8,11 @@
 @import UIKit;
 #import <CocoaLumberjack/CocoaLumberjack.h>
 #import "SPLumberjackLogFormatter.h"
+#import "VialerSIPLib.h"
 
 // Definition of the current log level
 #ifdef DEBUG
-static const int ddLogLevel = DDLogLevelDebug;
+static const int ddLogLevel = DDLogLevelVerbose;
 #else
 static const int ddLogLevel = DDLogLevelWarning;
 #endif

--- a/Pod/Classes/VSLAccount.m
+++ b/Pod/Classes/VSLAccount.m
@@ -266,10 +266,13 @@ static NSString * const VSLAccountErrorDomain = @"VialerSIPLib.VSLAccount";
                 }
             }];
         }
+        self.registrationInProgress = NO;
     } else if (PJSIP_IS_STATUS_IN_CLASS(code, 100) || PJSIP_IS_STATUS_IN_CLASS(code, 300)) {
         self.accountState = VSLAccountStateConnecting;
+        self.registrationInProgress = YES;
     } else if (PJSIP_IS_STATUS_IN_CLASS(code, 200)) {
         self.accountState = VSLAccountStateConnected;
+        self.registrationInProgress = NO;
         // Registration is succesfull.
         if (self.registrationCompletionBlock) {
             VSLLogVerbose(@"Account registered succesfully");

--- a/Pod/Classes/VSLCall.h
+++ b/Pod/Classes/VSLCall.h
@@ -22,6 +22,7 @@ extern NSString * _Nonnull const VSLCallStateChangedNotification;
  */
 extern NSString * _Nonnull const VSLNotificationUserInfoVideoSizeRenderKey;
 
+extern NSString * _Nonnull const VSLCallDeallocNotification;
 
 /**
  *  Notification that will be posted when a phonecall is connected.

--- a/Pod/Classes/VSLCall.m
+++ b/Pod/Classes/VSLCall.m
@@ -23,6 +23,7 @@ NSString * const VSLCallStateChangedNotification = @"VSLCallStateChangedNotifica
 NSString * const VSLNotificationUserInfoVideoSizeRenderKey = @"VSLNotificationUserInfoVideoSizeRenderKey";
 NSString * const VSLCallConnectedNotification = @"VSLCallConnectedNotification";
 NSString * const VSLCallDisconnectedNotification = @"VSLCallDisconnectedNotification";
+NSString * const VSLCallDeallocNotification = @"VSLCallDeallocNotification";
 
 @interface VSLCall()
 @property (readwrite, nonatomic) VSLCallState callState;
@@ -96,6 +97,9 @@ NSString * const VSLCallDisconnectedNotification = @"VSLCallDisconnectedNotifica
 }
 
 - (void)dealloc {
+    [[NSNotificationCenter defaultCenter] postNotificationName:VSLCallDeallocNotification
+                                                        object:nil
+                                                      userInfo:nil];
     VSLLogVerbose(@"Dealloc Call uuid:%@ id:%ld", self.uuid.UUIDString, (long)self.callId);
 }
 
@@ -229,6 +233,7 @@ NSString * const VSLCallDisconnectedNotification = @"VSLCallDisconnectedNotifica
                                 errorDomain:VSLCallErrorDomain
                                   errorCode:VSLCallErrorCannotCreateCall];
     }
+
     completion(error);
 }
 

--- a/Pod/Classes/VSLRingback.m
+++ b/Pod/Classes/VSLRingback.m
@@ -71,6 +71,12 @@ static int const VSLRingbackInterval = 4000;
 }
 
 -(void)dealloc {
+    // Destory the conference port otherwise the maximum number of ports will reached and pjsip will crash.
+    pj_status_t status = pjsua_conf_remove_port((int)self.ringbackSlot);
+    if (status != PJ_SUCCESS) {
+        VSLLogWarning(@"Error removing the port!");
+    }
+    
     pjmedia_port_destroy(self.ringbackPort);
 }
 

--- a/Pod/Classes/VialerSIPLib.m
+++ b/Pod/Classes/VialerSIPLib.m
@@ -36,11 +36,14 @@ NSString * const VSLNotificationUserInfoWindowSizeKey = @"VSLNotificationUserInf
 
 + (BOOL)callKitAvailable {
     // Check if Callkit is available by checking the CallKit classes used
-    if ([CXAction class] && [CXTransaction class] && [CXCall class]) {
-        return true;
-    } else {
-        return false;
+    if (@available(iOS 10.0, *)) {
+        if ([CXAction class] && [CXTransaction class] && [CXCall class]) {
+            return true;
+        } else {
+            return false;
+        }
     }
+    return false;
 }
 
 - (VSLEndpoint *)endpoint {

--- a/VialerSIPLib.podspec
+++ b/VialerSIPLib.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
 
 	s.resource_bundles  = { 'VialerSIPLib' => 'Pod/Resources/*.wav' }
 
-	s.dependency 'Vialer-pjsip-iOS'
+    s.dependency 'Vialer-pjsip-iOS'
 	s.dependency 'CocoaLumberjack'
     s.dependency 'Reachability'
 end


### PR DESCRIPTION
- Codebase was updated to be compatible with XCode 9
- Warnings about documentation are fixed where it is possible
- Updated the Vialer-PJSIP-iOS pod to 3.0.0 for PJSIP 2.7
- Added a notification which can be listened to for when a call has been deallocated
