### PR TITLE
Fixed issue with disappearing sound when swap calls via CallKit.

### DIFF
--- a/Pod/Classes/CallKitProviderDelegate.m
+++ b/Pod/Classes/CallKitProviderDelegate.m
@@ -206,9 +206,7 @@ NSString * const CallKitProviderDelegateInboundCallRejectedNotification = @"Call
         VSLLogError(@"Could not hold call(%@). Error: %@", call.uuid.UUIDString, holdError);
         [action fail];
     } else {
-        if (call.onHold) {
-            [self.callManager.audioController deactivateAudioSession];
-        }
+        call.onHold ? [self.callManager.audioController deactivateAudioSession] : [self.callManager.audioController activateAudioSession];
         [action fulfill];
     }
 }


### PR DESCRIPTION
### Expected behaviour
Sound works for active call correctly 

### Actual behaviour
Sound stops working when use swap for calls via CallKit native screen

### Description of fix
Added method "activateAudioSession" that being fired for the call going from hold state to active state