### PR TITLE
Fixed reachability issue in case proxy server is not used for sip account.

### DIFF
--- a/Pod/Classes/VSLEndpoint.m
+++ b/Pod/Classes/VSLEndpoint.m
@@ -111,7 +111,10 @@ static pjsip_transport *the_transport;
 
         NSString *reachabilityServer = @"sipproxy.voipgrid.nl";
         if (activeAccount) {
-            reachabilityServer = activeAccount.accountConfiguration.sipProxyServer;
+            if (!activeAccount.accountConfiguration.sipProxyServer || [activeAccount.accountConfiguration.sipProxyServer length] < 7)
+                reachabilityServer = activeAccount.accountConfiguration.sipDomain;
+            else
+                reachabilityServer = activeAccount.accountConfiguration.sipProxyServer;
         }
         _networkMonitor = [[VSLNetworkMonitor alloc] initWithHost:reachabilityServer];
     }

--- a/Pod/Classes/VSLEndpoint.m
+++ b/Pod/Classes/VSLEndpoint.m
@@ -111,7 +111,7 @@ static pjsip_transport *the_transport;
 
         NSString *reachabilityServer = @"sipproxy.voipgrid.nl";
         if (activeAccount) {
-            if (!activeAccount.accountConfiguration.sipProxyServer || [activeAccount.accountConfiguration.sipProxyServer length] < 7)
+            if (!activeAccount.accountConfiguration.sipProxyServer || [activeAccount.accountConfiguration.sipProxyServer length] == 0)
                 reachabilityServer = activeAccount.accountConfiguration.sipDomain;
             else
                 reachabilityServer = activeAccount.accountConfiguration.sipProxyServer;


### PR DESCRIPTION
### Expected behaviour
Reachability manager should monitor internet connection and reregister account when connection dropped.

### Actual behaviour
Reachability manager was using only proxy server address for sip account.

### Description of fix
Sip accounts might not have proxy addresses, but have domain server.
Thus added logic to monitor either proxy or domain address for sip account.