### PR TITLE
 Fix issue when there were no calls possible from the background when video is disabled remove the video codec option from the INVITE

### DIFF
--- a/Pod/Classes/CallKitProviderDelegate.m
+++ b/Pod/Classes/CallKitProviderDelegate.m
@@ -8,6 +8,7 @@
 
 #import "VialerSIPLib.h"
 #import "VSLAudioController.h"
+#import "VSLEndpoint.h"
 #import "VSLLogging.h"
 
 NSString * const CallKitProviderDelegateOutboundCallStartedNotification = @"CallKitProviderDelegateOutboundCallStarted";
@@ -50,7 +51,7 @@ NSString * const CallKitProviderDelegateInboundCallRejectedNotification = @"Call
         
         providerConfiguration.maximumCallGroups = 2;
         providerConfiguration.maximumCallsPerCallGroup = 1;
-        providerConfiguration.supportsVideo = false;
+        providerConfiguration.supportsVideo = ![VSLEndpoint sharedEndpoint].endpointConfiguration.disableVideoSupport;
         
         NSString *ringtoneFileName = [[NSBundle mainBundle] pathForResource:@"ringtone" ofType:@"wav"];
         if (ringtoneFileName) {

--- a/Pod/Classes/VSLAccount.h
+++ b/Pod/Classes/VSLAccount.h
@@ -134,7 +134,7 @@ typedef void (^RegistrationCompletionBlock)(BOOL success, NSError * _Nullable er
  *  Will unregister the account and will re-register the account once the account
  *  state reaches "unregistered".
  */
-- (void) reregisterAccount;
+- (void)reregisterAccount;
 
 /**
  *  This will remove the account from the Endpoint and will also de-register the account from the server.

--- a/Pod/Classes/VSLAccount.m
+++ b/Pod/Classes/VSLAccount.m
@@ -246,6 +246,7 @@ static NSString * const VSLAccountErrorDomain = @"VialerSIPLib.VSLAccount";
         }
     } else {
         VSLLogVerbose(@"VSLAccount registered or registration in progress, cannot sent another registration");
+        VSLLogVerbose(@"VSLAccount state: %ld", (long)self.accountState);
     }
 
     // Check if account is connected, otherwise set completionblock.

--- a/Pod/Classes/VSLCall.m
+++ b/Pod/Classes/VSLCall.m
@@ -378,7 +378,14 @@ NSString * const VSLCallDeallocNotification = @"VSLCallDeallocNotification";
     pj_status_t status;
 
     if (self.callId != PJSUA_INVALID_ID) {
-        status = pjsua_call_answer((int)self.callId, PJSIP_SC_OK, NULL, NULL);
+        pjsua_call_setting callSetting;
+        pjsua_call_setting_default(&callSetting);
+
+        if ([VSLEndpoint sharedEndpoint].endpointConfiguration.disableVideoSupport) {
+            callSetting.vid_cnt = 0;
+        }
+
+        status = pjsua_call_answer2((int)self.callId, &callSetting, PJSIP_SC_OK, NULL, NULL);
 
         if (status != PJ_SUCCESS) {
             VSLLogError(@"Could not answer call PJSIP returned status code:%d", status);

--- a/Pod/Classes/VialerSIPLib.h
+++ b/Pod/Classes/VialerSIPLib.h
@@ -174,6 +174,11 @@ typedef NS_ENUM(NSUInteger, VialerSIPLibErrors) {
  */
 @property (readonly, nonatomic) BOOL endpointAvailable;
 
+/**
+ * If the endpoint is configured with TLS.
+ */
+@property (readonly, nonatomic) BOOL hasTLSTransport;
+
 /*
  *  The callManager used by the Lib.
  */

--- a/Pod/Classes/VialerSIPLib.m
+++ b/Pod/Classes/VialerSIPLib.m
@@ -54,10 +54,11 @@ NSString * const VSLNotificationUserInfoWindowSizeKey = @"VSLNotificationUserInf
 }
 
 - (BOOL)endpointAvailable {
-    if (self.endpoint.state == VSLEndpointStarted) {
-        return YES;
-    }
-    return NO;
+    return self.endpoint.state == VSLEndpointStarted;
+}
+
+- (BOOL)hasTLSTransport {
+    return self.endpoint.state == VSLEndpointStarted && self.endpoint.endpointConfiguration.hasTLSConfiguration;
 }
 
 - (VSLCallManager *)callManager {


### PR DESCRIPTION
Added a check for an incoming call that when using video is disabled remove the video from the INVITE.
And added an extra exposed function to see if the endpoint is started with a TLS configuration