### PR TITLE
Post notification when there is an error aftter an register

### DIFF
--- a/Pod/Classes/VSLCall.h
+++ b/Pod/Classes/VSLCall.h
@@ -33,6 +33,11 @@ extern NSString * _Nonnull const VSLCallDeallocNotification;
 extern NSString * _Nonnull const VSLCallNoAudioForCallNotification;
 
 /**
+ * Notification for when there is an error setting up a call.
+ */
+extern NSString * _Nonnull const VSLCallErrorDuringSetupCallNotification;
+
+/**
  *  Notification that will be posted when a phonecall is connected.
  */
 extern NSString * _Nonnull const VSLCallConnectedNotification DEPRECATED_MSG_ATTRIBUTE("Deprecated, listen for VSLCallStateChangedNotification instead");

--- a/Pod/Classes/VSLCall.m
+++ b/Pod/Classes/VSLCall.m
@@ -25,6 +25,7 @@ NSString * const VSLCallConnectedNotification = @"VSLCallConnectedNotification";
 NSString * const VSLCallDisconnectedNotification = @"VSLCallDisconnectedNotification";
 NSString * const VSLCallDeallocNotification = @"VSLCallDeallocNotification";
 NSString * const VSLCallNoAudioForCallNotification = @"VSLCallNoAudioForCallNotification";
+NSString * const VSLCallErrorDuringSetupCallNotification = @"VSLCallErrorDuringSetupCallNotification";
 
 @interface VSLCall()
 @property (readwrite, nonatomic) VSLCallState callState;

--- a/Pod/Classes/VialerSIPLib.h
+++ b/Pod/Classes/VialerSIPLib.h
@@ -44,6 +44,17 @@ extern NSString * __nonnull const VSLNotificationUserInfoCallStateKey;
 extern NSString * __nonnull const VSLNotificationUserInfoCallAudioStateKey;
 
 /**
+ *  Key to be used for retrieving the status code when there is an error setting up a call.
+ */
+extern NSString * __nonnull const VSLNotificationUserInfoErrorStatusCodeKey;
+
+/**
+ *  Key to be used for retrieving the status message when there is an error setting up a call.
+ */
+extern NSString * __nonnull const VSLNotificationUserInfoErrorStatusMessageKey;
+
+
+/**
  *  Possible errors the VialerSIPLib can return.
  */
 typedef NS_ENUM(NSUInteger, VialerSIPLibErrors) {

--- a/Pod/Classes/VialerSIPLib.m
+++ b/Pod/Classes/VialerSIPLib.m
@@ -18,6 +18,8 @@ NSString * const VSLNotificationUserInfoWindowIdKey = @"VSLNotificationUserInfoW
 NSString * const VSLNotificationUserInfoWindowSizeKey = @"VSLNotificationUserInfoWindowSizeKey";
 NSString * const VSLNotificationUserInfoCallStateKey = @"VSLNotificationUserInfoCallStateKey";
 NSString * const VSLNotificationUserInfoCallAudioStateKey = @"VSLNotificationUserInfoCallAudioStateKey";
+NSString * const VSLNotificationUserInfoErrorStatusCodeKey = @"VSLNotificationUserInfoErrorStatusCodeKey";
+NSString * const VSLNotificationUserInfoErrorStatusMessageKey = @"VSLNotificationUserInfoErrorStatusMessageKey";
 
 @interface VialerSIPLib()
 @property (strong, nonatomic) VSLEndpoint *endpoint;


### PR DESCRIPTION
Added a notification that will check the sip log messages if there is actually an error being thrown in the 4xx or 5xx range. 
