### PR TITLE
Resolved crash when muting the call without a valid conf port

### DIFF
--- a/Example/VialerSIPLib/SipUser.swift
+++ b/Example/VialerSIPLib/SipUser.swift
@@ -13,7 +13,7 @@ class SipUser: NSObject, SIPEnabledUser {
     let sipProxy: String?
     let sipRegisterOnAdd: Bool
 
-    init(sipAccount: String, sipPassword: String, sipDomain: String, sipProxy: String) {
+    init(sipAccount: String, sipPassword: String, sipDomain: String, sipProxy: String?) {
         self.sipAccount = sipAccount
         self.sipPassword = sipPassword
         self.sipDomain = sipDomain
@@ -23,6 +23,6 @@ class SipUser: NSObject, SIPEnabledUser {
     }
 
     convenience override init() {
-        self.init(sipAccount: Keys.SIP.Account, sipPassword: Keys.SIP.Password, sipDomain: Keys.SIP.Domain, sipProxy: Keys.SIP.Proxy)
+        self.init(sipAccount: Keys.SIP.Account, sipPassword: Keys.SIP.Password, sipDomain: Keys.SIP.Domain, sipProxy: Keys.SIP.Proxy.isEmpty ? nil : Keys.SIP.Proxy)
     }
 }

--- a/Pod/Classes/VSLCall.m
+++ b/Pod/Classes/VSLCall.m
@@ -579,6 +579,15 @@ NSString * const VSLCallErrorDuringSetupCallNotification = @"VSLCallErrorDuringS
     pjsua_call_info callInfo;
     pjsua_call_get_info((pjsua_call_id)self.callId, &callInfo);
 
+    if (callInfo.conf_slot <= 0) {
+        if (error != NULL) {
+            NSDictionary *userInfo = @{NSLocalizedDescriptionKey:NSLocalizedString(@"Could not toggle mute call", nil)};
+            *error = [NSError errorWithDomain:VSLCallErrorDomain code:VSLCallErrorCannotToggleMute userInfo:userInfo];
+        }
+        VSLLogError(@"Unable to toggle mute, pjsua has not provided a valid conf_slot for this call");
+        return NO;
+    }
+
     pj_status_t status;
     if (!self.muted) {
         status = pjsua_conf_disconnect(0, callInfo.conf_slot);


### PR DESCRIPTION
### Issue number

#176 

### Expected behavior

It should be possible to mute the call as many times as you like.

### Actual behavior

Muting and unmuting will eventually cause the app to crash.

### Description of fix

The callInfo object occasionally gives an invalid (-1) conf_slot, when you attempt to disconnect the microphone using while specifying this invalid conf_slot, an assertion will fail (and a crash occurs). If we encounter this invalid conf_slot we will now just report the error and that we were unable to mute/unmute the call.

### Other info

Also fixed an issue that caused the example app to fail to register because the SipProxy was an empty string rather than nil.