### PR TITLE
Fixed issue where mute would be reset on media state change

### DIFF
--- a/Example/VialerSIPLib/VSLCallViewController.swift
+++ b/Example/VialerSIPLib/VSLCallViewController.swift
@@ -170,10 +170,16 @@ class VSLCallViewController: UIViewController, VSLKeypadViewControllerDelegate {
         }
     }
 
-    @objc func noAudioForCall() {
+    @objc func noAudioForCall(_ notification : NSNotification) {
         guard let call = activeCall, call.callState != .disconnected else { return }
-
-        call.reinvite()
+        
+        guard let userData = notification.object as? NSDictionary else { return }
+        
+        guard let audioState = userData[VSLNotificationUserInfoCallAudioStateKey] as? Int else { return }
+        
+        if (audioState == VSLCallAudioState.noAudioBothDirections.rawValue) {
+            call.reinvite();
+        }
     }
 
     @objc func updateUI() {

--- a/Pod/Classes/VSLCall.m
+++ b/Pod/Classes/VSLCall.m
@@ -429,7 +429,9 @@ NSString * const VSLCallErrorDuringSetupCallNotification = @"VSLCallErrorDuringS
             [self.ringback stop];
         }
         pjsua_conf_connect(callInfo.conf_slot, 0);
-        pjsua_conf_connect(0, callInfo.conf_slot);
+        if (!self.muted) {
+            pjsua_conf_connect(0, callInfo.conf_slot);
+        }
     }
 
     if (self.mediaState == VSLMediaStateActive && ![self.audioCheckTimer isValid]) {


### PR DESCRIPTION
### Issue number

#165 

### Expected behavior

When muting a call, this should persist and not be reset.

### Actual behavior

Whenever mediaStateChanged is called (e.g. during reINVITE), the microphone is connected again and therefore mute is reset.

### Description of fix

Only re-connecting the microphone if mute is disabled. 

### Other info

Also updated the example application to inspect the no call audio notification and only reinviting the call when the notification is saying that there is no audio for both directions.