### PR TITLE
Enable Voice Activity Detection

### DIFF
--- a/Pod/Classes/VSLEndpoint.m
+++ b/Pod/Classes/VSLEndpoint.m
@@ -206,7 +206,7 @@ static void onTransportStateChanged(pjsip_transport *tp, pjsip_transport_state s
     mediaConfig.snd_clock_rate = (unsigned int)endpointConfiguration.sndClockRate;
     mediaConfig.has_ioqueue = PJ_TRUE;
     mediaConfig.thread_cnt = 1;
-    mediaConfig.no_vad = PJ_TRUE;
+    mediaConfig.no_vad = PJ_FALSE;
 
     // Initialize Endpoint.
     status = pjsua_init(&endpointConfig, &logConfig, &mediaConfig);


### PR DESCRIPTION
### Issue number

NA

### Expected behavior

Start a call and be able to hear each other with high quality audio (opus) enabled.

### Actual behavior

The other party hears nothing, until putting the call on hold / off hold 

### Description of fix

no_vad was set to true, changed it to false, therefore enabling vad.

### Other info

Not satisfying fix because it was unclear why the sound problem started to appear in the first place.
