### PR TITLE
Update SIP message is not implemented by Asteriks, so don't send it

### DIFF
--- a/Pod/Classes/VSLEndpoint.m
+++ b/Pod/Classes/VSLEndpoint.m
@@ -623,8 +623,7 @@ static void onRegState2(pjsua_acc_id acc_id, pjsua_reg_info *info) {
                         [[[VSLEndpoint sharedEndpoint] callManager] reinviteActiveCallsForAccount:account];
                         break;
                     case VSLIpChangeConfigurationIpChangeCallsUpdate:
-                        VSLLogInfo(@"Do a update for all calls of account: %d", acc_id);
-                        [[[VSLEndpoint sharedEndpoint] callManager] updateActiveCallsForAccount:account];
+                        // Do nothing. Update is not implemented by Asterisk.
                         break;
                     case VSLIpChangeConfigurationIpChangeCallsDefault:
                         // Do nothing.


### PR DESCRIPTION
### Issue number

VIALI-3651

### Expected behavior

When switching networks during a call (ie WIFI > 4G) an INVITE sip message is sent. 

### Actual behavior

When switching networks an UPDATE and INVITE sip message are sent, where the UPDATE always gets a `501 Method Not Implemented` response. This doesn't have negative effects on the phone call itself, but makes debugging or investigating harder since there are unnecessary and failing communication steps. 

### Description of fix

Don't call `updateActiveCallsForAccount` on ip change.

### Other info

from Asterisk [chan_sip.c](https://github.com/asterisk/asterisk/blob/master/channels/chan_sip.c):
 ```
* XXX This is not even close to being RFC 3311-compliant. We don't advertise
* that we support the UPDATE method, so no one should ever try sending us
* an UPDATE anyway.
``` 
