### PR TITLE
Fix for invite messages sent from Windows machine

### DIFF
--- a/Pod/Classes/SipInvite.m
+++ b/Pod/Classes/SipInvite.m
@@ -86,8 +86,9 @@ static NSString *const P_ASSERTED_IDENTITY_KEY = @"P-Asserted-Identity";
  */
 - (NSString *) findLineContaining:(NSString *)key inPacket:(char*) packet {
     NSString *packetAsString = [NSString stringWithUTF8String:packet];
-    NSArray *lines = [packetAsString componentsSeparatedByString:@"\n"];
-    
+    NSString *lineSeparator = [packetAsString rangeOfString:@"\r\n"].location != NSNotFound ? @"\r\n" : @"\n";
+    NSArray *lines = [packetAsString componentsSeparatedByString:lineSeparator];
+
     for (id line in lines) {
         if ([line hasPrefix:key]) {
             return [line stringByReplacingOccurrencesOfString:[NSString stringWithFormat:@"%@: ", key] withString:@""];


### PR DESCRIPTION
Fix for invite messages sent from Windows machine (with \r\n new line characters instead of \n)

### Issue number

{if exists provide related issue}

### Expected behavior

Caller name should be parsed successfully from the invite message

### Actual behavior

When the invite message arrives with \r\n new lines then it is not parsed properly - each parsed line ends with "\r". It causes the caller name not to be parsed because it doesn't match the corresponding regex in VSLCall.m:758 (the regex is '.+\\\\s<.+>')

### Description of fix

Before the fix in SipInvite.m:89 the invite message was split to separate lines using "\n". 
The fix is to check whether the line separators in the invite message are "\r\n" and use it if so. 
Otherwise fallback to "\n".

### Other info

{anything else that might be related/useful}