### PR TITLE
Add TURN configuration to SIPEnabledUser.

### DIFF
--- a/Pod/Classes/VialerSIPLib.h
+++ b/Pod/Classes/VialerSIPLib.h
@@ -144,6 +144,11 @@ typedef NS_ENUM(NSUInteger, VialerSIPLibErrors) {
 @property (readonly, nonatomic) VSLIceConfiguration * _Nullable iceConfiguration;
 
 /**
+ *  The TURN Configuration that should be used.
+ */
+@property (readonly, nonatomic) VSLTurnConfiguration * _Nullable turnConfiguration;
+
+/**
  * Specify if source TCP port should be used as the initial Contact
  * address if TCP/TLS transport is used. Note that this feature will
  * be automatically turned off when nameserver is configured because

--- a/Pod/Classes/VialerSIPLib.m
+++ b/Pod/Classes/VialerSIPLib.m
@@ -140,6 +140,10 @@ NSString * const VSLNotificationUserInfoErrorStatusMessageKey = @"VSLNotificatio
             accountConfiguration.iceConfiguration = sipUser.iceConfiguration;
         }
 
+        if ([sipUser respondsToSelector:@selector(turnConfiguration)]) {
+            accountConfiguration.turnConfiguration = sipUser.turnConfiguration;
+        }
+
         if ([sipUser respondsToSelector:@selector(contactUseSrcPort)]) {
             accountConfiguration.contactUseSrcPort = sipUser.contactUseSrcPort;
         }


### PR DESCRIPTION
Hello team :), first off thank you for this, it really helped me grasp PJSIP a lot better.

### Issue number

- There is no issue at the moment, at least I can't find it. 

### Expected behavior

It should be possible to set TURN configuration on `SIPEnabledUser`, so that calling the method

```objc
- (VSLAccount *)createAccountWithSipUser:(id<SIPEnabledUser>  _Nonnull __autoreleasing)sipUser error:(NSError * _Nullable __autoreleasing *)error
```

produces proper `VSLAccount`. By proper I mean one where TURN configuration is applied to `PJSIP` core.

### Actual behavior

As there is no way to set TURN configuration on `SIPEnabledUser`, my first take was to use

```swift
func setupAccount() {
    do {
        account = try VialerSIPLib.sharedInstance().createAccount(withSip: SipUser())
    } catch let error {
        DDLogWrapper.logError("Could not create account. Error:\(error)\nExiting")
        assert(false)
    }
}
```

and then on this newly created account access read-only property `VSLAccountConfiguration`. And then apply TURN configuration.
Unfortunately this will not trigger application to `PJSIP` core.

### Description of fix

I have added TURN configuration to `SIPEnabledUser`

```objc
/**
 *  The TURN Configuration that should be used.
 */
@property (readonly, nonatomic) VSLTurnConfiguration * _Nullable turnConfiguration;
```

and configuration application on `VialerSIPLib` method `createAccountWithSipUser`

```objc
    if ([sipUser respondsToSelector:@selector(turnConfiguration)]) {
        accountConfiguration.turnConfiguration = sipUser.turnConfiguration;
    }
```

### Other info

I would also expect for the configuration to be applied to `PJSIP` core even if I access `VSLAccountConfiguration` trough `VSLAccount`.
Let me know how you feel about this and if I missunderstood correct approach for this. Thx guys!
