### PR TITLE
VIALI-3838:Fixed UI threading issue and registered thread for PJSIP

### DIFF
--- a/Pod/Classes/VSLEndpoint.m
+++ b/Pod/Classes/VSLEndpoint.m
@@ -404,6 +404,14 @@ static void onTransportStateChanged(pjsip_transport *tp, pjsip_transport_state s
     const unsigned audioCodecInfoSize = 64;
     pjsua_codec_info audioCodecInfo[audioCodecInfoSize];
     unsigned audioCodecCount = audioCodecInfoSize;
+    
+    // Register thread if needed.
+    NSError *threadError;
+    if (![self createPJSIPThreadWithError:&threadError]) {
+        VSLLogError(@"Error registering the thread for PJSIP: %@", threadError);
+        return NO;
+    }
+    
     pj_status_t status = pjsua_enum_codecs(audioCodecInfo, &audioCodecCount);
     if (status != PJ_SUCCESS) {
         char statusmsg[PJ_ERR_MSG_SIZE];

--- a/Pod/Classes/VialerSIPLib.m
+++ b/Pod/Classes/VialerSIPLib.m
@@ -66,7 +66,9 @@ NSString * const VSLNotificationUserInfoErrorStatusMessageKey = @"VSLNotificatio
 
 - (BOOL)configureLibraryWithEndPointConfiguration:(VSLEndpointConfiguration * _Nonnull)endpointConfiguration error:(NSError * _Nullable __autoreleasing *)error {
     // Make sure interrupts are handled by pjsip
-    [[UIApplication sharedApplication] beginReceivingRemoteControlEvents];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[UIApplication sharedApplication] beginReceivingRemoteControlEvents];
+    });    
 
     // Start the Endpoint
     NSError *endpointConfigurationError;


### PR DESCRIPTION
### Issue number

https://voipgrid.atlassian.net/browse/VIALI-3838

### Expected behavior
x-code should not complain about threading issues. app should not delay on first outgoing call on debug and it should not crash either.

### Actual behavior
x-code complains about threading issues on the start of the 1st outgoing call. app should not delay on first outgoing call on debug and should not crash either.

{what happens}

### Description of fix

Fixed UI threading issue and registered thread for PJSIP
