### PR TITLE
RetryFirstIntervalSec and RetryIntervalSec were added to be used in SipUser()

### DIFF
--- a/Pod/Classes/Configurations/VSLAccountConfiguration.h
+++ b/Pod/Classes/Configurations/VSLAccountConfiguration.h
@@ -109,6 +109,40 @@ typedef NS_ENUM(NSUInteger, VSLContactRewriteMethod) {
 @property (nonatomic) BOOL sipRegisterOnAdd;
 
 /**
+* Specify interval of auto registration retry upon registration failure
+* (including caused by transport problem), in second. Set to 0 to
+* disable auto re-registration. Note that if the registration retry
+* occurs because of transport failure, the first retry will be done
+* after \a firstRetryIntervalSec seconds instead. Also note that
+* the interval will be randomized slightly by some seconds (specified
+* in \a reg_retry_random_interval) to avoid all clients re-registering
+* at the same time.
+*
+* See also \a firstRetryIntervalSec and \a randomRetryIntervalSec
+* settings.
+*
+* Default: PJSUA_REG_RETRY_INTERVAL
+*/
+@property (nonatomic) unsigned int retryIntervalSec;
+
+/**
+* Specify interval of auto registration retry upon registration failure
+* (including caused by transport problem), in second. Set to 0 to
+* disable auto re-registration. Note that if the registration retry
+* occurs because of transport failure, the first retry will be done
+* after \a firstRetryIntervalSec seconds instead. Also note that
+* the interval will be randomized slightly by some seconds (specified
+* in \a reg_retry_random_interval) to avoid all clients re-registering
+* at the same time.
+*
+* See also \a firstRetryIntervalSec and \a randomRetryIntervalSec
+* settings.
+*
+* Default: PJSUA_REG__FIRST_RETRY_INTERVAL
+*/
+@property (nonatomic) unsigned int retryFirstIntervalSec;
+
+/**
  *  If YES, the account presence will be published to the server where the account belongs.
  */
 @property (nonatomic) BOOL sipPublishEnabled;

--- a/Pod/Classes/VSLAccount.m
+++ b/Pod/Classes/VSLAccount.m
@@ -111,6 +111,15 @@ static NSString * const VSLAccountErrorDomain = @"VialerSIPLib.VSLAccount";
     acc_cfg.id = [[accountConfiguration.sipAddress stringByAppendingString:transportString] prependSipUri].pjString;
     acc_cfg.reg_uri = [[accountConfiguration.sipDomain stringByAppendingString:transportString] prependSipUri].pjString;
     acc_cfg.register_on_acc_add = accountConfiguration.sipRegisterOnAdd ? PJ_TRUE : PJ_FALSE;
+    
+    acc_cfg.reg_first_retry_interval = accountConfiguration.retryFirstIntervalSec ? accountConfiguration.retryFirstIntervalSec : 10;
+    NSLog(@"lib");
+    NSLog(@"%i", acc_cfg.reg_first_retry_interval);
+    NSLog(@"%i", accountConfiguration.retryFirstIntervalSec);
+    acc_cfg.reg_retry_interval = accountConfiguration.retryIntervalSec ? accountConfiguration.retryIntervalSec : 300;
+    NSLog(@"lib");
+    NSLog(@"%i ", acc_cfg.reg_retry_interval);
+    NSLog(@"%i ", accountConfiguration.retryIntervalSec);
     acc_cfg.publish_enabled = accountConfiguration.sipPublishEnabled ? PJ_TRUE : PJ_FALSE;
     acc_cfg.reg_timeout = VSLAccountRegistrationTimeoutInSeconds;
     acc_cfg.drop_calls_on_reg_fail = accountConfiguration.dropCallOnRegistrationFailure ? PJ_TRUE : PJ_FALSE;

--- a/Pod/Classes/VSLAccount.m
+++ b/Pod/Classes/VSLAccount.m
@@ -113,13 +113,7 @@ static NSString * const VSLAccountErrorDomain = @"VialerSIPLib.VSLAccount";
     acc_cfg.register_on_acc_add = accountConfiguration.sipRegisterOnAdd ? PJ_TRUE : PJ_FALSE;
     
     acc_cfg.reg_first_retry_interval = accountConfiguration.retryFirstIntervalSec ? accountConfiguration.retryFirstIntervalSec : 10;
-    NSLog(@"lib");
-    NSLog(@"%i", acc_cfg.reg_first_retry_interval);
-    NSLog(@"%i", accountConfiguration.retryFirstIntervalSec);
     acc_cfg.reg_retry_interval = accountConfiguration.retryIntervalSec ? accountConfiguration.retryIntervalSec : 300;
-    NSLog(@"lib");
-    NSLog(@"%i ", acc_cfg.reg_retry_interval);
-    NSLog(@"%i ", accountConfiguration.retryIntervalSec);
     acc_cfg.publish_enabled = accountConfiguration.sipPublishEnabled ? PJ_TRUE : PJ_FALSE;
     acc_cfg.reg_timeout = VSLAccountRegistrationTimeoutInSeconds;
     acc_cfg.drop_calls_on_reg_fail = accountConfiguration.dropCallOnRegistrationFailure ? PJ_TRUE : PJ_FALSE;

--- a/Pod/Classes/VialerSIPLib.h
+++ b/Pod/Classes/VialerSIPLib.h
@@ -107,6 +107,13 @@ typedef NS_ENUM(NSUInteger, VialerSIPLibErrors) {
  */
 @property (readonly, nonatomic) BOOL sipRegisterOnAdd;
 
+
+@property (readonly, nonatomic) unsigned int retryIntervalSec;
+@optional
+
+
+@property (readonly, nonatomic) unsigned int retryFirstIntervalSec;
+@optional
 /**
  *  When set to YES, calls will be dropped after registration fails.
  *

--- a/Pod/Classes/VialerSIPLib.m
+++ b/Pod/Classes/VialerSIPLib.m
@@ -113,6 +113,14 @@ NSString * const VSLNotificationUserInfoErrorStatusMessageKey = @"VSLNotificatio
         if ([sipUser respondsToSelector:@selector(sipRegisterOnAdd)]) {
             accountConfiguration.sipRegisterOnAdd = sipUser.sipRegisterOnAdd;
         }
+        
+        if ([sipUser respondsToSelector:@selector(retryFirstIntervalSec)]) {
+            accountConfiguration.retryFirstIntervalSec = sipUser.retryFirstIntervalSec;
+        }
+        
+        if ([sipUser respondsToSelector:@selector(retryIntervalSec)]) {
+            accountConfiguration.retryIntervalSec = sipUser.retryIntervalSec;
+        }
 
         if ([sipUser respondsToSelector:@selector(dropCallOnRegistrationFailure)]) {
             accountConfiguration.dropCallOnRegistrationFailure = sipUser.dropCallOnRegistrationFailure;

--- a/VialerSIPLib.podspec
+++ b/VialerSIPLib.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
 	s.name             	= "VialerSIPLib"
-	s.version          	= "3.7.1"
+	s.version          	= "3.7.2"
 	s.summary          	= "Vialer SIP Library for iOS"
 	s.description      	= "Objective-C wrapper around PJSIP."
 	s.homepage         	= "https://github.com/VoIPGRID/VialerSIPLib"


### PR DESCRIPTION
### Issue number

#211 

### Expected behavior

I would like to parameter  `RetryFirstIntervalSec` and `RetryIntervalSec`

### Actual behavior

Default values are used.

### Description of fix

I've added `RetryFirstIntervalSec` and `RetryIntervalSec` parameter to SipUser
